### PR TITLE
Add automatic upgrade info parameter to set-lmcollector

### DIFF
--- a/Documentation/Set-LMCollector.md
+++ b/Documentation/Set-LMCollector.md
@@ -17,7 +17,7 @@ schema: 2.0.0
 Set-LMCollector [-Id <Int32>] [-Description <String>] [-BackupAgentId <Int32>] [-CollectorGroupId <Int32>]
  [-Properties <Hashtable>] [-EnableFailBack <Boolean>] [-EnableFailOverOnCollectorDevice <Boolean>]
  [-EscalatingChainId <Int32>] [-SuppressAlertClear <Boolean>] [-ResendAlertInterval <Int32>]
- [-SpecifiedCollectorDeviceGroupId <Int32>] [<CommonParameters>]
+ [-SpecifiedCollectorDeviceGroupId <Int32>] [-AutomaticUpgradeInfo <PSObject>] [<CommonParameters>]
 ```
 
 ### Name
@@ -25,7 +25,7 @@ Set-LMCollector [-Id <Int32>] [-Description <String>] [-BackupAgentId <Int32>] [
 Set-LMCollector [-Name <String>] [-Description <String>] [-BackupAgentId <Int32>] [-CollectorGroupId <Int32>]
  [-Properties <Hashtable>] [-EnableFailBack <Boolean>] [-EnableFailOverOnCollectorDevice <Boolean>]
  [-EscalatingChainId <Int32>] [-SuppressAlertClear <Boolean>] [-ResendAlertInterval <Int32>]
- [-SpecifiedCollectorDeviceGroupId <Int32>] [<CommonParameters>]
+ [-SpecifiedCollectorDeviceGroupId <Int32>] [-AutomaticUpgradeInfo <PSObject>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -212,6 +212,20 @@ Accept wildcard characters: False
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -AutomaticUpgradeInfo
+{{ Fill BackupAgentId Description }}
+
+```yaml
+Type: PSObject
 Parameter Sets: (All)
 Aliases:
 

--- a/Public/Set-LMCollector.ps1
+++ b/Public/Set-LMCollector.ps1
@@ -27,7 +27,9 @@ Function Set-LMCollector {
 
         [Nullable[Int]]$ResendAlertInterval,
 
-        [Nullable[Int]]$SpecifiedCollectorDeviceGroupId
+        [Nullable[Int]]$SpecifiedCollectorDeviceGroupId,
+
+        [PsObject]$AutomaticUpgradeInfo
 
     )
     #Check if we are logged in and have valid api creds
@@ -69,6 +71,7 @@ Function Set-LMCollector {
                     resendIval                      = $ResendAlertInterval
                     netflowCollectorId              = $NetflowCollectorId
                     specifiedCollectorDeviceGroupId = $SpecifiedCollectorDeviceGroupId
+                    automaticUpgradeInfo = $AutomaticUpgradeInfo
                 }
 
             


### PR DESCRIPTION
I recently ran into an issue where I needed to change the escalating chain ID for all collectors. I did so using set-lmcollector, but found afterwards that the automatic upgrade schedule we set was removed. Adding the parameter 'automaticupgradeinfo' accepting a PSObject, allows reusing the current upgrade schedule information. 