### PR TITLE
5.1 Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,97 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish
     steps:
-      - uses: actions/checkout@v3
       - name: Build and publish
-      # API key generated in PSGallery
+        id: psgallery-publish
+        uses: actions/checkout@v3
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           BUILD_VERSION: ${{github.ref_name}}
         shell: pwsh
         run: |
           ./Build.ps1
-          Publish-Module -path ./ -NuGetApiKey $env:NUGET_API_KEY -SkipAutomaticTags -Verbose          
+          Publish-Module -path ./ -NuGetApiKey $env:NUGET_API_KEY -SkipAutomaticTags -Verbose
+      - name: Send custom JSON data to Slack workflow
+        id: slack-post
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":party-lm-bug: Logic.Monitor PowerShell Module Release (${{github.event.release.tag_name}})  :party-lm-bug:"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "text": "*${{github.event.release.published_at}}*  | Logic.Monitor Update Announcements",
+                      "type": "mrkdwn"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":powershell-core: Release Notes :powershell-core:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{github.event.release.body}}"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Full/Previous Release Notes"
+                    },
+                    "url": "https://github.com/stevevillardi/Logic.Monitor/releases"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":rocket: How to get the latest version :rocket:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "```Update-Module -Name Logic.Monitor -Force```"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ":pushpin: Do you have a feature request or bug report? <https://github.com/stevevillardi/Logic.Monitor/issues|Submit a Github Issue>."
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK   

--- a/Logic.Monitor.Format.ps1xml
+++ b/Logic.Monitor.Format.ps1xml
@@ -54,6 +54,59 @@
             </TableRowEntries>
          </TableControl>
       </View>
+      <!-- New View LogicMonitor.Report-->
+      <View>
+         <Name>LogicMonitorReport</Name>
+         <ViewSelectedBy>
+            <TypeName>LogicMonitor.Report</TypeName>
+         </ViewSelectedBy>
+         <TableControl>
+            <TableHeaders>
+               <TableColumnHeader>
+                  <Label>id</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>name</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>type</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>format</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>groupId</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>description</Label>
+               </TableColumnHeader>
+            </TableHeaders>
+            <TableRowEntries>
+               <TableRowEntry>
+                  <TableColumnItems>
+                     <TableColumnItem>
+                        <PropertyName>id</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>name</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>type</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>format</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>groupId</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>description</PropertyName>
+                     </TableColumnItem>
+                  </TableColumnItems>
+               </TableRowEntry>
+            </TableRowEntries>
+         </TableControl>
+      </View>
       <!-- New View LogicMonitor.DeviceGroupDatasource-->
       <View>
          <Name>LogicMonitorDeviceGroupDatasource</Name>

--- a/Public/Copy-LMDashboard.ps1
+++ b/Public/Copy-LMDashboard.ps1
@@ -1,0 +1,90 @@
+Function Copy-LMDashboard {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$Name,
+
+        [Parameter(Mandatory, ParameterSetName = 'GroupId-Id')]
+        [Parameter(Mandatory, ParameterSetName = 'GroupName-Id')]
+        [String]$DashboardId,
+
+        [Parameter(Mandatory, ParameterSetName = 'GroupId-Name')]
+        [Parameter(Mandatory, ParameterSetName = 'GroupName-Name')]
+        [String]$DashboardName,
+
+        [String]$Description,
+
+        [Parameter(Mandatory, ParameterSetName = 'GroupId-Id')]
+        [Parameter(Mandatory, ParameterSetName = 'GroupId-Name')]
+        [Int]$ParentGroupId,
+
+        [Parameter(Mandatory, ParameterSetName = 'GroupName-Id')]
+        [Parameter(Mandatory, ParameterSetName = 'GroupName-Name')]
+        [String]$ParentGroupName
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+
+        #Lookup ParentGroupName
+        If ($ParentGroupName) {
+            If ($ParentGroupName -Match "\*") {
+                Write-Error "Wildcard values not supported for groups names."
+                return
+            }
+            $ParentGroupId = (Get-LMDashboardGroup -Name $ParentGroupName | Select-Object -First 1 ).Id
+            If (!$ParentGroupId) {
+                Write-Error "Unable to find dashboard group: $ParentGroupName, please check spelling and try again." 
+                return
+            }
+        }
+
+        #Lookup Dashboard Id
+        If($DashboardName) {
+            $LookupResult = (Get-LMDashboard -Name $DashboardName).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $DashboardName) {
+                return
+            }
+            $DashboardId = $LookupResult
+        }
+
+        #Get existing dashboard config
+        $SourceDashboard = Get-LMDashboard -Id $DashboardId
+        
+        #Build header and uri
+        $ResourcePath = "/dashboard/dashboards/$DashboardId/clone"
+
+        Try {
+            $Data = @{
+                name                                = $Name
+                description                         = $Description
+                groupId                             = $ParentGroupId
+                widgetTokens                        = $SourceDashboard.widgetTokens
+                widgetsConfig                       = $SourceDashboard.widgetsConfig
+                widgetsOrder                        = $SourceDashboard.widgetsOrder
+                sharable                           = $SourceDashboard.sharable
+            }
+
+            $Data = ($Data | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+            Return $Response
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Copy-LMDevice.ps1
+++ b/Public/Copy-LMDevice.ps1
@@ -1,0 +1,72 @@
+Function Copy-LMDevice {
+
+    [CmdletBinding()]
+    Param (
+
+        [Parameter(Mandatory)]
+        [String]$Name,
+
+        [String]$DisplayName = $Name,
+
+        [String]$Description,
+
+        [Parameter(Mandatory)]
+        $DeviceObject
+    )
+    #Check if we are logged in and have valid api creds
+    Begin {
+        Write-Output "[INFO]: Any custom properties from the reference device that are masked will need to be updated on the cloned resource as those values are not available to the LM API."
+    }
+    Process {
+        If ($Script:LMAuth.Valid) {
+            #Strip out dynamic groups
+            $HostGroupIds = ($DeviceObjec.hostGroupIds -Split "," | Get-LMDeviceGroup | Where-Object {$_.appliesTo -eq ""}).Id -Join ","
+
+            $Data = @{
+                name                      = $Name
+                displayName               = If($DisplayName){$DisplayName}Else{$DeviceObject.displayName}
+                description               = If($Description){$Description}Else{$DeviceObject.description}
+                disableAlerting           = $DeviceObject.disableAlerting
+                enableNetflow             = $DeviceObject.enableNetFlow
+                customProperties          = $DeviceObject.customProperties
+                deviceType                = $DeviceObject.deviceType
+                preferredCollectorId      = $DeviceObject.preferredCollectorId
+                preferredCollectorGroupId = $DeviceObject.preferredCollectorGroupId
+                autoBalancedCollectorGroupId = $DeviceObject.autoBalancedCollectorGroupId
+                link                      = $DeviceObject.link
+                netflowCollectorGroupId   = $DeviceObject.netflowCollectorGroupId
+                netflowCollectorId        = $DeviceObject.netflowCollectorId
+                logCollectorGroupId       = $DeviceObject.logCollectorGroupId
+                logCollectorId            = $DeviceObject.logCollectorId
+                hostGroupIds              = If($HostGroupIds){$HostGroupIds}Else{1}
+            }
+                    
+            #Build header and uri
+            $ResourcePath = "/device/devices"
+
+            Try {
+                $Data = ($Data | ConvertTo-Json)
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data
+                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                #Issue request
+                $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Device" )
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {
+    }
+}

--- a/Public/Copy-LMReport.ps1
+++ b/Public/Copy-LMReport.ps1
@@ -1,0 +1,49 @@
+Function Copy-LMReport {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$Name,
+
+        [String]$Description,
+
+        [String]$ParentGroupId,
+
+        [Parameter(Mandatory)]
+        $ReportObject
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+
+        #Replace name and description if present
+        $ReportObject.name = $Name
+        If($Description){$ReportObject.description = $Description}
+        If($ParentGroupId){$ReportObject.groupId = $ParentGroupId}
+        
+        #Build header and uri
+        $ResourcePath = "/report/reports"
+
+        Try {
+            $Data = ($ReportObject | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+            Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Report" )
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Get-LMReport.ps1
+++ b/Public/Get-LMReport.ps1
@@ -54,7 +54,7 @@ Function Get-LMReport {
                 #Stop looping if single device, no need to continue
                 If ($PSCmdlet.ParameterSetName -eq "Id") {
                     $Done = $true
-                    Return $Response
+                    Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Report" )
                 }
                 #Check result size and if needed loop again
                 Else {
@@ -73,7 +73,7 @@ Function Get-LMReport {
                 }
             }
         }
-        Return $Results
+        Return (Add-ObjectTypeInfo -InputObject $Results -TypeName "LogicMonitor.Report" )
     }
     Else {
         Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."

--- a/Public/New-LMDevice.ps1
+++ b/Public/New-LMDevice.ps1
@@ -32,7 +32,11 @@ Function New-LMDevice {
 
         [Nullable[Int]]$NetflowCollectorGroupId,
 
-        [Nullable[Int]]$NetflowCollectorId
+        [Nullable[Int]]$NetflowCollectorId,
+
+        [Nullable[Int]]$LogCollectorGroupId,
+
+        [Nullable[Int]]$LogCollectorId
     )
     #Check if we are logged in and have valid api creds
     Begin {}
@@ -65,6 +69,8 @@ Function New-LMDevice {
                     link                      = $Link
                     netflowCollectorGroupId   = $NetflowCollectorGroupId
                     netflowCollectorId        = $NetflowCollectorId
+                    logCollectorGroupId       = $LogCollectorGroupId
+                    logCollectorId            = $LogCollectorId
                     hostGroupIds              = $HostGroupIds -join ","
                 }
 

--- a/Public/Remove-LMReport.ps1
+++ b/Public/Remove-LMReport.ps1
@@ -1,0 +1,69 @@
+Function Remove-LMReport {
+
+    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [Int]$Id,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String]$Name
+
+    )
+    Begin {}
+    Process {
+        #Check if we are logged in and have valid api creds
+        If ($Script:LMAuth.Valid) {
+
+            #Lookup Id if supplying name
+            If ($Name) {
+                $LookupResult = (Get-LMReport -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            If($PSItem){
+                $Message = "Id: $Id | Name: $($PSItem.name)"
+            }
+            ElseIf($Name){
+                $Message = "Id: $Id | Name: $Name"
+            }
+            Else{
+                $Message = "Id: $Id"
+            }
+            
+            #Build header and uri
+            $ResourcePath = "/report/reports/$Id"
+
+            Try {
+                If ($PSCmdlet.ShouldProcess($Message, "Remove Report")) {                    
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "DELETE" -ResourcePath $ResourcePath
+                    $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+    
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+                #Issue request
+                    $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
+                    
+                    $Result = [PSCustomObject]@{
+                        Id = $Id
+                        Message = "Successfully removed ($Message)"
+                    }
+                    
+                    Return $Result
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/Public/Set-LMDevice.ps1
+++ b/Public/Set-LMDevice.ps1
@@ -14,9 +14,9 @@ Function Set-LMDevice {
 
         [String]$Description,
 
-        [String]$PreferredCollectorId,
+        [Nullable[Int]]$PreferredCollectorId,
 
-        [String]$PreferredCollectorGroupId,
+        [Nullable[Int]]$PreferredCollectorGroupId,
 
         [Hashtable]$Properties,
 
@@ -31,9 +31,13 @@ Function Set-LMDevice {
 
         [Nullable[boolean]]$EnableNetFlow,
 
-        [String]$NetflowCollectorGroupId,
+        [Nullable[Int]]$NetflowCollectorGroupId,
 
-        [String]$NetflowCollectorId
+        [Nullable[Int]]$NetflowCollectorId,
+
+        [Nullable[Int]]$LogCollectorGroupId,
+
+        [Nullable[Int]]$LogCollectorId
     )
     #Check if we are logged in and have valid api creds
     Begin {}
@@ -83,6 +87,8 @@ Function Set-LMDevice {
                     link                      = $Link
                     netflowCollectorGroupId   = $NetflowCollectorGroupId
                     netflowCollectorId        = $NetflowCollectorId
+                    logCollectorGroupId       = $LogCollectorGroupId
+                    logCollectorId            = $LogCollectorId
                     hostGroupIds              = $HostGroupIds -join ","
                 }
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 #### Dashboards
 
 - Get-LMDashboard
+- Copy-LMDashboard
 - Get-LMDashboardGroup
 - Get-LMDashboardWidget
 - Remove-LMDashboard*
@@ -225,6 +226,7 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 
 #### Devices
 
+- Copy-LMDevice
 - Get-LMDevice
 - Get-LMDeviceSDT
 - Get-LMDeviceSDTHistory
@@ -256,7 +258,7 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 
 #### Device Groups
 
-- Get-LMDeviceGroup
+- Get-LMDeviceGroup*
 - Get-LMDeviceGroupSDT
 - Get-LMDeviceGroupSDTHistory
 - Get-LMDeviceGroupAlerts*
@@ -324,11 +326,13 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 
 #### Reports
 
+- Copy-LMReport
 - Get-LMReport
 - Get-LMReportGroup
 - New-LMReportGroup
 - Set-LMReportGroup*
 - Remove-LMReportGroup*
+- Remove-LMReport*
 
 #### Repository (LogicModules)
 
@@ -390,11 +394,38 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 
 # Change List
 
-## 5.0.2
-###### Bug Fixes:
-**Get-LMCollectorVersions**:
-- Added -Top parameter to only return current versions of LM Collector.
-**Invoke-LMActiveDiscovery**:
-- Fixed bug causing targeted groups to only execute for the first device in the list.
+## 5.1
+###### Updated Cmdlets:
+**New-LMDevice**:
+- Added support for *LogCollectorGroupId* and *LogCollectorId*.
+**Set-LMDevice**:
+- Added support for *LogCollectorGroupId* and *LogCollectorId*.
+**Get-LMReport**:
+- Added output format for report objects.
+**Get-LMDeviceGroup**:
+- Added pipeline processing for Id.
+
+###### New Cmdlets:
+**Remove-LMReport**:
+- Delete a specified report by name or id.
+**Copy-LMDashboard**:
+- Clone a dashboard by specifying an existing dashboard within an LM portal.
+**Copy-LMReport**:
+- Clone a report by specifying an existing report within an LM portal.
+**Copy-LMDevice**:
+- Clone a device/resource by specifying an existing device/resource. Note: If the device is assigned masked custom properties, they must be updated after cloning as the values for those properties cannot be retrieved by the LM API.
+
+###### New Cmdlets Usage Examples:
+```powershell
+#Create a new device using device id 123 as a reference
+Copy-LMDevice -Name newdevice.example.com -DisplayName newdevice -DeviceObject $(Get-LMDevice -id 123)
+
+#Clone an existing dashboard with id 25 but place it in a different group with a new description
+Copy-LMDashboard -Name NewClonedDashboard -DasbhaordId 25 -ParentGroupId 2 -Description "New Cloned Dashboard"
+
+#Clone an existing report with id 75 and change the report group it belongs to
+Copy-LMReport -Name NewReport -Description "New Description" -ParentGroupId 3 -ReportObject $(Get-LMReport -Id 75)
+
+```
 
 [Previous Release Notes](RELEASENOTES.md)

--- a/README.md
+++ b/README.md
@@ -390,24 +390,11 @@ New-LMAPIToken -Username jdoe@example.com -Note "Used for K8s"
 
 # Change List
 
-## 5.0.1
-###### New cmdlets:
-**New-LMReportGroup**:
-- Create new report group and set a description
-**Set-LMReportGroup**:
-- Update existing report group. Accepts pipeline input.
-**New-LMReportGroup**:
-- Delete specified report group. Accepts pipeline input.
-
-###### Updated cmdlets:
-**New-LMWebsite**:
-- Add support for specifying checkpoints when creating webchecks.
-**Set-LMX Commands**:
-- Add support for -WhatIf parameter
-
+## 5.0.2
 ###### Bug Fixes:
-**Get-LMDeviceAlertSettings**:
-- Fix bug causing pipeline process to not work correctly
-
+**Get-LMCollectorVersions**:
+- Added -Top parameter to only return current versions of LM Collector.
+**Invoke-LMActiveDiscovery**:
+- Fixed bug causing targeted groups to only execute for the first device in the list.
 
 [Previous Release Notes](RELEASENOTES.md)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,23 @@
 # Previous module release notes
+## 5.0.1
+###### New cmdlets:
+**New-LMReportGroup**:
+- Create new report group and set a description
+**Set-LMReportGroup**:
+- Update existing report group. Accepts pipeline input.
+**New-LMReportGroup**:
+- Delete specified report group. Accepts pipeline input.
+
+###### Updated cmdlets:
+**New-LMWebsite**:
+- Add support for specifying checkpoints when creating webchecks.
+**Set-LMX Commands**:
+- Add support for -WhatIf parameter
+
+###### Bug Fixes:
+**Get-LMDeviceAlertSettings**:
+- Fix bug causing pipeline process to not work correctly
+
 ## 5.0
 ###### New features/Breaking changes:
 **Support for -WhatIf parameter on destructive cmdlets**:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,11 @@
 # Previous module release notes
+## 5.0.2
+###### Bug Fixes:
+**Get-LMCollectorVersions**:
+- Added -Top parameter to only return current versions of LM Collector.
+**Invoke-LMActiveDiscovery**:
+- Fixed bug causing targeted groups to only execute for the first device in the list.
+
 ## 5.0.1
 ###### New cmdlets:
 **New-LMReportGroup**:


### PR DESCRIPTION
## 5.1
### Updated Cmdlets:
- **New-LMDevice**:
  - Added support for *LogCollectorGroupId* and *LogCollectorId*.

- **Set-LMDevice**:
  - Added support for *LogCollectorGroupId* and *LogCollectorId*.

- **Get-LMReport**:
  - Added output format for report objects.

- **Get-LMDeviceGroup**:
  - Added pipeline processing for Id.

### New Cmdlets:
- **Remove-LMReport**:
   - Delete a specified report by name or id.

- **Copy-LMDashboard**:
  - Clone a dashboard by specifying an existing dashboard within an LM portal.

- **Copy-LMReport**:
  - Clone a report by specifying an existing report within an LM portal.

- **Copy-LMDevice**:
  - Clone a device/resource by specifying an existing device/resource. Note: If the device is assigned masked custom properties, they must be updated after cloning as the values for those properties cannot be retrieved by the LM API.

### New Cmdlets Usage Examples:
```powershell
#Create a new device using device id 123 as a reference
Copy-LMDevice -Name newdevice.example.com -DisplayName newdevice -DeviceObject $(Get-LMDevice -id 123)

#Clone an existing dashboard with id 25 but place it in a different group with a new description
Copy-LMDashboard -Name NewClonedDashboard -DasbhaordId 25 -ParentGroupId 2 -Description "New Cloned Dashboard"

#Clone an existing report with id 75 and change the report group it belongs to
Copy-LMReport -Name NewReport -Description "New Description" -ParentGroupId 3 -ReportObject $(Get-LMReport -Id 75)

```